### PR TITLE
Use a locally-stored remark.js to allow offline use

### DIFF
--- a/remarkjs/Dockerfile
+++ b/remarkjs/Dockerfile
@@ -1,12 +1,18 @@
 FROM nginx:1-alpine
 
-# install gomplate
-ENV GOMPLATE_VER v1.0.0
+ENV GOMPLATE_VER v1.1.2
+ENV REMARK_VER 0.14.0
+ENV WEBROOT /usr/share/nginx/html
+ENV TITLE My Title
+ENV RATIO 4:3
+ENV HIGHLIGHT_LINES false
+ENV HIGHLIGHT_STYLE default
+
 ADD https://github.com/hairyhenderson/gomplate/releases/download/$GOMPLATE_VER/gomplate_linux-amd64-slim /usr/local/bin/gomplate
 RUN chmod a+rx /usr/local/bin/gomplate
 
-ENV TITLE My Title
-
+ADD https://gnab.github.io/remark/downloads/remark-${REMARK_VER}.min.js /usr/share/nginx/html/
+RUN chmod a+r /usr/share/nginx/html/remark-${REMARK_VER}.min.js
 COPY index.html.tmpl /
 COPY docker-entrypoint.sh /
 

--- a/remarkjs/docker-entrypoint.sh
+++ b/remarkjs/docker-entrypoint.sh
@@ -6,7 +6,6 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'nginx' ]; then
-  WEBROOT=/usr/share/nginx/html
   gomplate < /index.html.tmpl > $WEBROOT/index.html
   if [ -f /slides.md.tmpl ]; then
     gomplate < /slides.md.tmpl > $WEBROOT/slides.md

--- a/remarkjs/index.html.tmpl
+++ b/remarkjs/index.html.tmpl
@@ -8,7 +8,7 @@
       @import url(https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
       @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
 
-      body { font-family: 'Droid Serif'; }
+      body { font-family: 'Droid Serif'; font-size: large }
       h1, h2, h3 {
         font-family: 'Yanone Kaffeesatz';
         font-weight: normal;
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body>
-    <script src="https://gateway.ipfs.io/ipfs/QmTc5kCXuuFyH9PH6QXwhmgx2wNMq3hNP8cooNCzGueW3j/remark.min.js"></script>
+    <script src="remark-{{getenv "REMARK_VER"}}.min.js"></script>
     <script>
       var slideshow = remark.create({
         sourceUrl: 'slides.md',


### PR DESCRIPTION
The IPFS caching of my locally-built remark.js didn't work out so well. So I'm bundling it in with the image (this works properly, now that 0.14.0 of remark.js is out).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>