### PR TITLE
Added DEV_MODE option

### DIFF
--- a/remarkjs/README.md
+++ b/remarkjs/README.md
@@ -11,4 +11,14 @@ $ docker run -d -p 8080:80 -v $(pwd)/slides.md:/slides.md hairyhenderson/remarkj
 $ open http://localhost:8080
 ```
 
+## Development Usage
+
+Enable development mode by setting the `DEV_MODE` environment variable to any value. Then, mount your slides at `/usr/share/nginx/html/slides.md`.
+
+```console
+$ docker run -p 8080:80 -v $(pwd)/slides.md:/usr/share/nginx/html/slides.md -e DEV_MODE=true hairyhenderson/remarkjs
+$ open http://localhost:8080
+```
+
+
 [remarkjs]: http://remarkjs.com/#1

--- a/remarkjs/docker-entrypoint.sh
+++ b/remarkjs/docker-entrypoint.sh
@@ -7,10 +7,14 @@ fi
 
 if [ "$1" = 'nginx' ]; then
   gomplate < /index.html.tmpl > $WEBROOT/index.html
-  if [ -f /slides.md.tmpl ]; then
-    gomplate < /slides.md.tmpl > $WEBROOT/slides.md
+  if [ -z "$DEV_MODE" ]; then
+    if [ -f /slides.md.tmpl ]; then
+      gomplate < /slides.md.tmpl > $WEBROOT/slides.md
+    else
+      cp /slides.md $WEBROOT/slides.md
+    fi
   else
-    cp /slides.md $WEBROOT/slides.md
+    echo "-- Starting with dev mode enabled"
   fi
 fi
 


### PR DESCRIPTION
The current image is a little difficult to use for slide development, as it copies `/slides.md` into `$WEBROOT/slides.md`.  So, it relies on having something at `/slides.md`.  If I try to mount directly to `/usr/share/nginx/html/slides.md`, the copy fails because it's the same file content at both locations.

So... DEV_MODE simply skips the copying in the entrypoint script.  Allows me to mount directly into the web root and work on my slides from there.

Feel free to tweak as needed.  Thanks for making the image and sharing! 👍 