### PR TITLE
Prevent browser caching of slides.md

### DIFF
--- a/remarkjs/index.html.tmpl
+++ b/remarkjs/index.html.tmpl
@@ -20,7 +20,7 @@
     <script src="remark-{{getenv "REMARK_VER"}}.min.js"></script>
     <script>
       var slideshow = remark.create({
-        sourceUrl: 'slides.md',
+        sourceUrl: 'slides.md?' + Math.random(),
         ratio: '{{getenv "RATIO" "4:3"}}',
         navigation: {
           scroll: false,


### PR DESCRIPTION
When swapping between slidedecks (using separate containers), I had to force the browser to refresh the cache, as `slides.md` was cached.  Throwing a random parameter at the end kills the cache, making it a little more responsive.