### PR TITLE
Downgrade golangci-lint to v1.23

### DIFF
--- a/gomplate-ci-build/Dockerfile
+++ b/gomplate-ci-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM vault:1.4.0 AS vault
 FROM consul:1.7.2 AS consul
 FROM docker:19.03 AS docker
-FROM golangci/golangci-lint:v1.24.0 AS golangci-lint
+FROM golangci/golangci-lint:v1.23.8 AS golangci-lint
 
 FROM golang:1.14.2 AS cc-test-reporter
 


### PR DESCRIPTION
Looks like we're running into https://github.com/golangci/golangci-lint/issues/1014

Signed-off-by: Dave Henderson <dhenderson@gmail.com>