### PR TITLE
Build multiple gomplate-ci-build tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,8 @@ jobs:
       run: echo ${{ steps.buildx.outputs.platforms }}
     - name: Build (non-main branch)
       run: |
-        docker buildx build --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --load gomplate-ci-build/
+        docker buildx build --build-arg GO_VERSION=1.17 --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --load gomplate-ci-build/
+        docker buildx build --build-arg GO_VERSION=1.18rc1 --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --load gomplate-ci-build/
       if: github.repository == 'hairyhenderson/dockerfiles'
     - name: Run Trivy vulnerability scanner (table output)
       uses: aquasecurity/trivy-action@master
@@ -339,18 +340,39 @@ jobs:
       run: |
         PLATFORMS=linux/amd64,linux/arm64
 
-        docker buildx build \
+        docker buildx build --build-arg GO_VERSION=1.17 \
           --platform $PLATFORMS \
           --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --push gomplate-ci-build/
-        docker buildx build \
+        docker buildx build --build-arg GO_VERSION=1.17 \
           --platform $PLATFORMS \
           --tag hairyhenderson/gomplate-ci-build:${{ github.sha }} --push gomplate-ci-build/
+
+        docker buildx imagetools create \
+          -t ghcr.io/hairyhenderson/gomplate-ci-build:1.17 \
+          ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }}
+        docker buildx imagetools create \
+          -t hairyhenderson/gomplate-ci-build:1.17 \
+          hairyhenderson/gomplate-ci-build:${{ github.sha }}
 
         docker buildx imagetools create \
           -t ghcr.io/hairyhenderson/gomplate-ci-build:latest \
           ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }}
         docker buildx imagetools create \
           -t hairyhenderson/gomplate-ci-build:latest \
+          hairyhenderson/gomplate-ci-build:${{ github.sha }}
+
+        docker buildx build --build-arg GO_VERSION=1.18rc1 \
+          --platform $PLATFORMS \
+          --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --push gomplate-ci-build/
+        docker buildx build --build-arg GO_VERSION=1.18rc1 \
+          --platform $PLATFORMS \
+          --tag hairyhenderson/gomplate-ci-build:${{ github.sha }} --push gomplate-ci-build/
+
+        docker buildx imagetools create \
+          -t ghcr.io/hairyhenderson/gomplate-ci-build:1.18 \
+          ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }}
+        docker buildx imagetools create \
+          -t hairyhenderson/gomplate-ci-build:1.18 \
           hairyhenderson/gomplate-ci-build:${{ github.sha }}
       if: github.repository == 'hairyhenderson/dockerfiles' && github.actor == 'hairyhenderson' && github.ref == 'refs/heads/main'
   docker-build-jwt:

--- a/.github/workflows/build.yml.tmpl
+++ b/.github/workflows/build.yml.tmpl
@@ -10,16 +10,16 @@ on:
     - cron: '42 2 * * 2'
 
 jobs:
-{{- range .dir }}
-{{- $isDir := file.IsDir . -}}
-{{ $hasDockerfile := file.Exists (filepath.Join . "Dockerfile") -}}
+{{- range $dir := .dir }}
+{{- $isDir := file.IsDir $dir -}}
+{{ $hasDockerfile := file.Exists (filepath.Join $dir "Dockerfile") -}}
 {{ $notHidden := not (strings.HasPrefix "." .) -}}
-{{ $noIgnore := not (file.Exists (filepath.Join . ".ignore")) -}}
+{{ $noIgnore := not (file.Exists (filepath.Join $dir ".ignore")) -}}
 {{ $bashbrewBuild := file.Exists (filepath.Join "library" .) -}}
 {{ if and $isDir $hasDockerfile $notHidden $noIgnore }}
   {{- if $bashbrewBuild }}
-  docker-build-{{ . }}:
-    name: docker build {{ . }}
+  docker-build-{{ $dir }}:
+    name: docker build {{ $dir }}
     runs-on: ubuntu-20.04
     container:
       image: hairyhenderson/dockerfiles-builder:latest
@@ -32,8 +32,8 @@ jobs:
         fetch-depth: 0
     - name: build
       run: |
-        bashbrew build {{ . }}
-        img=$(bashbrew ls {{ . }} --uniq | head -n1)
+        bashbrew build {{ $dir }}
+        img=$(bashbrew ls {{ $dir }} --uniq | head -n1)
         echo "IMG_NAME=${img}" >> $GITHUB_ENV
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
@@ -50,7 +50,7 @@ jobs:
         sarif_file: 'trivy-results.sarif'
       if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: tag
-      run: bashbrew tag --target-namespace {{ $ghcrns }} {{ . }}
+      run: bashbrew tag --target-namespace {{ $ghcrns }} {{ $dir }}
     - name: login
       run: |
         echo {{"${{ secrets.GHCR_TOKEN }}"}} | docker login {{ $ghcrhost }} --username {{ "${{ github.actor }}" }} --password-stdin
@@ -58,17 +58,22 @@ jobs:
       if: github.repository == 'hairyhenderson/dockerfiles' && github.actor == 'hairyhenderson'
     - name: push
       run: |
-        bashbrew push --dry-run {{ . }}
-        bashbrew push --dry-run --target-namespace {{ $ghcrns }} {{ . }}
+        bashbrew push --dry-run {{ $dir }}
+        bashbrew push --dry-run --target-namespace {{ $ghcrns }} {{ $dir }}
       if: github.ref != 'refs/heads/main' && github.repository == 'hairyhenderson/dockerfiles' && github.actor == 'hairyhenderson'
     - name: push
       run: |
-        bashbrew push {{ . }}
-        bashbrew push --target-namespace {{ $ghcrns }} {{ . }}
+        bashbrew push {{ $dir }}
+        bashbrew push --target-namespace {{ $ghcrns }} {{ $dir }}
       if: github.ref == 'refs/heads/main' && github.repository == 'hairyhenderson/dockerfiles'
   {{- else }}
-  docker-build-{{ . }}:
-    name: docker build {{ . }}
+  {{- $tagargsfile := filepath.Join $dir ".tag-args"}}
+  {{- $tagargs := jsonArray `[{"tags": ["latest"], "args": {}}]` }}
+  {{- if file.Exists $tagargsfile }}
+    {{- $tagargs = (file.Read $tagargsfile) | yamlArray }}
+  {{- end }}
+  docker-build-{{ $dir }}:
+    name: docker build {{ $dir }}
     runs-on: ubuntu-20.04
     env:
       DOCKER_BUILDKIT: 1
@@ -95,12 +100,14 @@ jobs:
       run: echo {{ `${{ steps.buildx.outputs.platforms }}` }}
     - name: Build (non-main branch)
       run: |
-        docker buildx build --tag {{ $ghcrns }}/{{ . }}:{{ `${{ github.sha }}` }} --load {{ . }}/
+        {{- range $a := $tagargs }}
+        docker buildx build{{range $k, $v := $a.args}} --build-arg {{$k}}={{$v}}{{end}} --tag {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }} --load {{ $dir }}/
+        {{- end }}
       if: github.repository == 'hairyhenderson/dockerfiles'
     - name: Run Trivy vulnerability scanner (table output)
       uses: aquasecurity/trivy-action@master
       with:
-        image-ref: '{{ $ghcrns }}/{{ . }}:{{ `${{ github.sha }}` }}'
+        image-ref: '{{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }}'
         format: 'table'
         exit-code: 1
         ignore-unfixed: true
@@ -109,7 +116,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       with:
-        image-ref: '{{ $ghcrns }}/{{ . }}:{{ `${{ github.sha }}` }}'
+        image-ref: '{{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }}'
         format: 'template'
         template: '@/contrib/sarif.tpl'
         output: 'trivy-results.sarif'
@@ -137,25 +144,31 @@ jobs:
       if: github.repository == 'hairyhenderson/dockerfiles' && github.actor == 'hairyhenderson' && github.ref == 'refs/heads/main'
     - name: Build & Push (main branch)
       run: |
-        {{- if file.Exists (filepath.Join . ".docker-platforms") }}
-        PLATFORMS={{ file.Read (filepath.Join . ".docker-platforms") | strings.TrimSpace }}
+        {{- if file.Exists (filepath.Join $dir ".docker-platforms") }}
+        PLATFORMS={{ file.Read (filepath.Join $dir ".docker-platforms") | strings.TrimSpace }}
         {{- else }}
         PLATFORMS=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
         {{- end }}
 
-        docker buildx build \
+        {{- range $a := $tagargs }}
+
+        docker buildx build{{range $k, $v := $a.args}} --build-arg {{$k}}={{$v}}{{end}} \
           --platform $PLATFORMS \
-          --tag {{ $ghcrns }}/{{ . }}:{{ `${{ github.sha }}` }} --push {{ . }}/
-        docker buildx build \
+          --tag {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }} --push {{ $dir }}/
+        docker buildx build{{range $k, $v := $a.args}} --build-arg {{$k}}={{$v}}{{end}} \
           --platform $PLATFORMS \
-          --tag hairyhenderson/{{ . }}:{{ `${{ github.sha }}` }} --push {{ . }}/
+          --tag hairyhenderson/{{ $dir }}:{{ `${{ github.sha }}` }} --push {{ $dir }}/
+
+          {{- range $tag := $a.tags}}
 
         docker buildx imagetools create \
-          -t {{ $ghcrns }}/{{ . }}:latest \
-          {{ $ghcrns }}/{{ . }}:{{ `${{ github.sha }}` }}
+          -t {{ $ghcrns }}/{{ $dir }}:{{ $tag }} \
+          {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }}
         docker buildx imagetools create \
-          -t hairyhenderson/{{ . }}:latest \
-          hairyhenderson/{{ . }}:{{ `${{ github.sha }}` }}
+          -t hairyhenderson/{{ $dir }}:{{ $tag }} \
+          hairyhenderson/{{ $dir }}:{{ `${{ github.sha }}` }}
+          {{- end}}
+        {{- end }}
       if: github.repository == 'hairyhenderson/dockerfiles' && github.actor == 'hairyhenderson' && github.ref == 'refs/heads/main'
     {{- end }}
 {{- end }}{{ end }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dockerimage = "ghcr.io/hairyhenderson/$(patsubst %/image.tag,%,$(1))"
 clean:
 	-@rm */image.iid
 
-.github/workflows/build.yml: .github/workflows/build.yml.tmpl */.ignore */.docker-platforms */Dockerfile
+.github/workflows/build.yml: .github/workflows/build.yml.tmpl */.* */Dockerfile
 	@gomplate -c dir=./ -f $< -o $@
 
 .github/dependabot.yml: .github/dependabot.yml.tmpl */.ignore */Dockerfile

--- a/gomplate-ci-build/.tag-args
+++ b/gomplate-ci-build/.tag-args
@@ -1,0 +1,6 @@
+- tags: ['1.17', 'latest']
+  args:
+    GO_VERSION: '1.17'
+- tags: ['1.18']
+  args:
+    GO_VERSION: '1.18rc1'

--- a/gomplate-ci-build/Dockerfile
+++ b/gomplate-ci-build/Dockerfile
@@ -1,3 +1,4 @@
+ARG GO_VERSION=1.17
 FROM vault:1.9.3 AS vault
 FROM consul:1.11.3 AS consul
 FROM docker:20.10 AS docker
@@ -20,10 +21,10 @@ RUN set -eux; \
 	esac; \
 	chmod +x /bin/cc-test-reporter
 
-FROM golang:1.17.7 AS go-junit-report
-RUN go get -u github.com/jstemmer/go-junit-report
+FROM golang:${GO_VERSION} AS go-junit-report
+RUN go install github.com/jstemmer/go-junit-report@latest
 
-FROM golang:1.17.7 AS final
+FROM golang:${GO_VERSION} AS final
 
 LABEL org.opencontainers.image.source https://github.com/hairyhenderson/dockerfiles
 
@@ -35,6 +36,7 @@ RUN apt-get update \
 		jq \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
 		libexpat1 \
+		libsasl2-2 \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Allows building multiple tags with different build-args from a single Dockerfile. Also adds a Go 1.18(rc1) build for `gomplate-ci-build` and aliases `1.17` to `latest`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>