### PR TITLE
Temporarily build golangci-lint directly with go1.18

### DIFF
--- a/gomplate-ci-build/Dockerfile
+++ b/gomplate-ci-build/Dockerfile
@@ -2,9 +2,18 @@ ARG GO_VERSION=1.18
 FROM vault:1.9.4 AS vault
 FROM consul:1.11.4 AS consul
 FROM docker:20.10 AS docker
-FROM golangci/golangci-lint:v1.45.0-alpine AS golangci-lint
 FROM hairyhenderson/bashbrew:latest AS bashbrew
 FROM docker/buildx-bin:master AS buildx-plugin
+
+
+# Temporarily install it manually, until a 1.18-built image is available (1.45.1 maybe?)
+FROM golang:1.18-alpine AS golangci-lint
+# FROM golangci/golangci-lint:v1.45.0-alpine AS golangci-lint
+
+# copied from https://github.com/golangci/golangci-lint/blob/master/build/Dockerfile.alpine
+RUN apk --no-cache add gcc musl-dev git mercurial
+RUN CGO_ENABLED=0 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+RUN cp /go/bin/golangci-lint /usr/bin/golangci-lint
 
 FROM alpine:3.15 AS cc-test-reporter
 


### PR DESCRIPTION
Signed-off-by: Dave Henderson <dhenderson@gmail.com>