### PR TITLE
ci: remove Trivy vulnerability scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,42 +167,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/figlet:${{ github.sha }} --load figlet/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/figlet:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/figlet:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -264,42 +228,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/freeciv:${{ github.sha }} --load freeciv/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/freeciv:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/freeciv:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -361,42 +289,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }} --load gomplate-ci-build/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/gomplate-ci-build:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -458,42 +350,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/man:${{ github.sha }} --load man/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/man:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/man:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -555,42 +411,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/sed:${{ github.sha }} --load sed/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/sed:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/sed:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -652,42 +472,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/socat:${{ github.sha }} --load socat/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/socat:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/socat:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:
@@ -749,42 +533,6 @@ jobs:
       run: |
         docker buildx build --tag ghcr.io/hairyhenderson/ssh:${{ github.sha }} --load ssh/
       if: github.repository == 'hairyhenderson/dockerfiles'
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/ssh:${{ github.sha }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          ghcr.io/hairyhenderson/ssh:${{ github.sha }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:

--- a/.github/workflows/build.yml.tmpl
+++ b/.github/workflows/build.yml.tmpl
@@ -67,44 +67,6 @@ jobs:
         docker buildx build{{range $k, $v := $a.args}} --build-arg {{$k}}={{$v}}{{end}} --tag {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }} --load {{ $dir }}/
         {{- end }}
       if: github.repository == 'hairyhenderson/dockerfiles'
-    {{- if not $noScan }}
-    - name: Install Trivy
-      uses: aquasecurity/setup-trivy@v0.2.5
-      with:
-        version: v0.61.0
-        cache: true
-    - name: Download Trivy DB
-      run: |
-        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
-    - name: Run Trivy vulnerability scanner (table output)
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format table \
-          --exit-code 1 \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --severity CRITICAL,HIGH \
-          --skip-db-update \
-          {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }}
-    - name: Run Trivy vulnerability scanner
-      run: |
-        trivy image \
-          --scanners vuln \
-          --format sarif \
-          --output trivy-results.sarif \
-          --ignore-unfixed \
-          --pkg-types os,library \
-          --ignorefile .trivyignore \
-          --skip-db-update \
-          {{ $ghcrns }}/{{ $dir }}:{{ `${{ github.sha }}` }}
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-results.sarif'
-      if: always() && github.repository == 'hairyhenderson/dockerfiles'
-    {{- end }}
     - name: Login to GHCR
       uses: docker/login-action@v4.0.0
       with:


### PR DESCRIPTION
## Summary

- Remove Trivy image scanning steps from the Docker build workflow template
- Regenerate `build.yml` from the updated template